### PR TITLE
Add MySQL bar loader and backtest example

### DIFF
--- a/examples/backtest/mysql_backtest_demo.py
+++ b/examples/backtest/mysql_backtest_demo.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Run a minimal backtest using data stored in MySQL.
+
+The database must first be populated with Polygon aggregate bars using
+``hist_generation/polygon_to_mysql.py``.  This script then loads the bars and
+executes a simple EMA cross strategy using the Nautilus Trader backtest engine.
+"""
+from decimal import Decimal
+
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.config import BacktestEngineConfig, LoggingConfig
+from nautilus_trader.examples.strategies.ema_cross_long_only import (
+    EMACrossLongOnly,
+    EMACrossLongOnlyConfig,
+)
+from nautilus_trader.model import TraderId
+from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.enums import AccountType, OmsType
+from nautilus_trader.model.objects import Money
+
+from hist_generation.mysql_to_bars import load_bars_from_mysql
+
+
+if __name__ == "__main__":
+    bars, bar_type, instrument = load_bars_from_mysql()
+
+    engine = BacktestEngine(
+        config=BacktestEngineConfig(
+            trader_id=TraderId("BACKTEST_TRADER-001"),
+            logging=LoggingConfig(log_level="INFO"),
+        )
+    )
+
+    engine.add_venue(
+        venue=instrument.id.venue,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.CASH,
+        starting_balances=[Money(100_000, USD)],
+        base_currency=USD,
+        default_leverage=Decimal(1),
+    )
+
+    engine.add_instrument(instrument)
+    engine.add_data(bars)
+
+    strategy = EMACrossLongOnly(
+        EMACrossLongOnlyConfig(
+            instrument_id=instrument.id,
+            bar_type=bar_type,
+            trade_size=Decimal(100),
+        )
+    )
+    engine.add_strategy(strategy)
+
+    engine.run()
+    engine.dispose()

--- a/hist_generation/README.md
+++ b/hist_generation/README.md
@@ -1,0 +1,24 @@
+# Historical Data Generation and Backtesting
+
+This directory contains utilities for fetching historical data and loading it
+into a MySQL database as well as helpers to convert that data for Nautilus
+Trader backtests.
+
+## Usage
+
+1. **Fetch data from Polygon and populate MySQL**
+
+   ```bash
+   python hist_generation/polygon_to_mysql.py --config hist_generation/config.yaml
+   ```
+
+   Ensure the `config.yaml` file contains valid Polygon and MySQL credentials.
+
+2. **Run a backtest using the stored bars**
+
+   ```bash
+   python examples/backtest/mysql_backtest_demo.py
+   ```
+
+   The script loads the bars from MySQL, converts them to Nautilus Trader
+   objects and executes a simple EMA cross strategy.

--- a/hist_generation/mysql_to_bars.py
+++ b/hist_generation/mysql_to_bars.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Load Polygon aggregate bars from MySQL for Nautilus backtests.
+
+This utility reads the same ``config.yaml`` file used by ``polygon_to_mysql.py``
+and converts the stored OHLCV data into a list of ``Bar`` objects which can be
+consumed by the Nautilus Trader backtest engine.
+
+Example
+-------
+>>> bars, bar_type, instrument = load_bars_from_mysql()
+"""
+from __future__ import annotations
+
+from typing import Tuple, List
+
+import pandas as pd
+import mysql.connector
+import yaml
+
+from nautilus_trader.model.data import Bar, BarType
+from nautilus_trader.persistence.wranglers import BarDataWrangler
+from nautilus_trader.test_kit.providers import TestInstrumentProvider
+
+CONFIG_PATH = "hist_generation/config.yaml"
+
+
+def _load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_bars_from_mysql(config_path: str = CONFIG_PATH) -> Tuple[List[Bar], BarType, object]:
+    """Load OHLCV bars from MySQL using the given configuration.
+
+    Parameters
+    ----------
+    config_path : str
+        Path to the YAML configuration file with ``polygon`` and ``mysql``
+        sections.
+
+    Returns
+    -------
+    tuple
+        A tuple of ``(bars, bar_type, instrument)`` where ``bars`` is a list of
+        :class:`~nautilus_trader.model.data.Bar` objects ready for backtesting.
+    """
+    cfg = _load_config(config_path)
+    poly_cfg = cfg["polygon"]
+    mysql_cfg = cfg["mysql"]
+
+    ticker = poly_cfg["stocksTicker"]
+    multiplier = int(poly_cfg["multiplier"])
+    timespan = poly_cfg["timespan"].lower()
+
+    conn = mysql.connector.connect(
+        host=mysql_cfg["host"],
+        port=int(mysql_cfg["port"]),
+        user=mysql_cfg["username"],
+        password=mysql_cfg["password"],
+        database=mysql_cfg["database"],
+    )
+
+    query = (
+        "SELECT dt_utc AS timestamp, `open`, `high`, `low`, `close`, `volume` "
+        "FROM aggregates WHERE ticker=%s AND multiplier=%s AND timespan=%s ORDER BY ts_ms"
+    )
+    df = pd.read_sql(
+        query,
+        conn,
+        params=(ticker, multiplier, timespan),
+        parse_dates=["timestamp"],
+    )
+    conn.close()
+
+    df = df.set_index("timestamp")
+
+    instrument = TestInstrumentProvider.equity(symbol=ticker, venue="XNAS")
+    bar_type = BarType.from_str(
+        f"{instrument.id}-{multiplier}-{timespan.upper()}-LAST-EXTERNAL"
+    )
+
+    wrangler = BarDataWrangler(bar_type, instrument)
+    bars: List[Bar] = wrangler.process(df)
+
+    return bars, bar_type, instrument
+
+
+__all__ = ["load_bars_from_mysql"]


### PR DESCRIPTION
## Summary
- load OHLCV bars from the Polygon-populated MySQL database for use in Nautilus Trader
- backtest the loaded bars with a simple EMA cross strategy
- document workflow for generating data and running the demo backtest

## Testing
- `python -m py_compile hist_generation/mysql_to_bars.py examples/backtest/mysql_backtest_demo.py`
- `PYTHONPATH=. pytest hist_generation -q` *(fails: ModuleNotFoundError: No module named 'nautilus_trader.core.data')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b33680ac832b8175f404e18a425b