### PR TITLE
feat: store backtest results

### DIFF
--- a/examples/backtest/mysql_backtest_demo.py
+++ b/examples/backtest/mysql_backtest_demo.py
@@ -1,34 +1,38 @@
 #!/usr/bin/env python3
-"""Run a minimal backtest using data stored in MySQL.
+"""
+Run a minimal backtest using data stored in MySQL.
 
 The database must first be populated with Polygon aggregate bars using
 ``hist_generation/polygon_to_mysql.py``.  This script then loads the bars and
 executes a simple EMA cross strategy using the Nautilus Trader backtest engine.
+
 """
 from decimal import Decimal
-
-from nautilus_trader.backtest.engine import BacktestEngine
-from nautilus_trader.config import BacktestEngineConfig, LoggingConfig
-from nautilus_trader.examples.strategies.ema_cross_long_only import (
-    EMACrossLongOnly,
-    EMACrossLongOnlyConfig,
-)
-from nautilus_trader.model import TraderId
-from nautilus_trader.model.currencies import USD
-from nautilus_trader.model.enums import AccountType, OmsType
-from nautilus_trader.model.objects import Money
+from typing import Any, cast
 
 from hist_generation.mysql_to_bars import load_bars_from_mysql
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.backtest.result_store import store_result
+from nautilus_trader.config import BacktestEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.examples.strategies.ema_cross_long_only import EMACrossLongOnly
+from nautilus_trader.examples.strategies.ema_cross_long_only import EMACrossLongOnlyConfig
+from nautilus_trader.model import TraderId
+from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.objects import Money
 
 
 if __name__ == "__main__":
     bars, bar_type, instrument = load_bars_from_mysql()
+    instrument = cast(Any, instrument)
 
     engine = BacktestEngine(
         config=BacktestEngineConfig(
             trader_id=TraderId("BACKTEST_TRADER-001"),
             logging=LoggingConfig(log_level="INFO"),
-        )
+        ),
     )
 
     engine.add_venue(
@@ -48,9 +52,11 @@ if __name__ == "__main__":
             instrument_id=instrument.id,
             bar_type=bar_type,
             trade_size=Decimal(100),
-        )
+        ),
     )
     engine.add_strategy(strategy)
 
     engine.run()
+    result = engine.get_result()
+    store_result(result, strategy.id.value, "examples/backtest/results.jsonl")
     engine.dispose()

--- a/nautilus_trader/backtest/result_store.py
+++ b/nautilus_trader/backtest/result_store.py
@@ -1,0 +1,36 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2025 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .results import BacktestResult
+
+
+def store_result(result: BacktestResult, strategy_id: str, output_path: str | Path) -> None:
+    """
+    Append a backtest result with metadata to a JSON lines file.
+    """
+    record: dict[str, Any] = asdict(result)
+    record["strategy_id"] = strategy_id
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        json.dump(record, f)
+        f.write("\n")

--- a/tests/unit_tests/backtest/test_result_store.py
+++ b/tests/unit_tests/backtest/test_result_store.py
@@ -1,0 +1,61 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+repo_root = Path(__file__).resolve().parents[3]
+pkg = types.ModuleType("nautilus_trader")
+pkg.__path__ = [str(repo_root / "nautilus_trader")]
+sys.modules["nautilus_trader"] = pkg
+
+_results = _load_module(
+    repo_root / "nautilus_trader" / "backtest" / "results.py",
+    "nautilus_trader.backtest.results",
+)
+_store = _load_module(
+    repo_root / "nautilus_trader" / "backtest" / "result_store.py",
+    "nautilus_trader.backtest.result_store",
+)
+
+BacktestResult = _results.BacktestResult
+store_result = _store.store_result
+
+
+def test_store_result_appends_json(tmp_path: Path) -> None:
+    result = BacktestResult(
+        trader_id="T",
+        machine_id="M",
+        run_config_id=None,
+        instance_id="I",
+        run_id="R",
+        run_started=None,
+        run_finished=None,
+        backtest_start=None,
+        backtest_end=None,
+        elapsed_time=1.23,
+        iterations=10,
+        total_events=5,
+        total_orders=2,
+        total_positions=1,
+        stats_pnls={},
+        stats_returns={},
+    )
+    output_file = tmp_path / "results.jsonl"
+    store_result(result, "STRAT-1", output_file)
+
+    with output_file.open("r", encoding="utf-8") as f:
+        data = json.loads(f.readline())
+
+    assert data["strategy_id"] == "STRAT-1"
+    assert data["run_id"] == "R"


### PR DESCRIPTION
## Summary
- add helper to store backtest results and strategy metadata to JSONL
- persist results in MySQL backtest demo
- test result storage utility

## Testing
- `pytest tests/unit_tests/backtest/test_result_store.py --confcutdir=tests/unit_tests/backtest -q`
- `python -m py_compile hist_generation/mysql_to_bars.py examples/backtest/mysql_backtest_demo.py`
- `SKIP=mypy pre-commit run --files examples/backtest/mysql_backtest_demo.py nautilus_trader/backtest/result_store.py tests/unit_tests/backtest/test_result_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7bb2699d0832b866d9a4c59cd8136